### PR TITLE
Add existing community proposals

### DIFF
--- a/_proposals/community/THfE_amongUs.md
+++ b/_proposals/community/THfE_amongUs.md
@@ -1,0 +1,22 @@
+---
+layout: proposal
+title: Tea Hours for Everyone: AmongUs Game Night
+authors: Hernando Martinez Vergara
+subgroup: community
+category: completed
+date: 2021-01-08
+---
+
+Host an AmongUs game
+
+### Purpose
+
+See the [**Tea Hours for Everyone proposal**](https://sainsburywellcomecentre.github.io/RCWG/proposals/community/teaHoursForEveryone)
+
+
+### Implementation
+
+- write instructions for putative participants (download the game, practice in free-play mode, etc)
+- explore hosting the game on discord vs zoom
+- advertise on slack / via email
+- have fun!

--- a/_proposals/community/THfE_pubQuiz.md
+++ b/_proposals/community/THfE_pubQuiz.md
@@ -1,0 +1,20 @@
+---
+layout: proposal
+title: Tea Hours for Everyone: Seasonal Pub Quiz
+authors: Svenja Nierwetberg
+subgroup: community
+category: completed
+date: 2020-10-15
+---
+
+Host a festive, neuroscience-free pub quiz
+
+
+### Purpose
+
+See the [**Tea Hours for Everyone proposal**](https://sainsburywellcomecentre.github.io/RCWG/proposals/community/teaHoursForEveryone)
+
+
+### Implementation
+
+- Svenja works her magic!

--- a/_proposals/community/coffeeRoulette.md
+++ b/_proposals/community/coffeeRoulette.md
@@ -1,0 +1,30 @@
+---
+layout: proposal
+title: Coffee Roulette
+authors: April Cashin-Garbutt
+subgroup: community
+category: active
+date: 2021-01-08
+---
+
+An opportunity to meet people over coffee
+
+
+### Purpose
+
+Boost the sense of belonging by giving people an extra chance to meet others (virtually at least for the moment) that they do not usually interact with, particularly during lockdown.
+
+
+### Concept
+
+Everyone gets a randomly assigned coffee partner every x weeks (where x depends on the participants' vote), and each pair is given a fun conversation starter. The pairs organise their (currently virtual) meetings themselves using the dedicated slack channel, private messages, or any other platform of their choice.
+
+
+### Implementation
+
+- gauge interest by posting on #general slack 
+- write code to generate pairs 
+- create a slack channel for organising coffee dates #social-coffee-roulette
+- come up with conversation starters
+- ask participants to vote on meeting frequency
+- run code every x weeks (where x = preferred meeting frequency)

--- a/_proposals/community/secretSanta.md
+++ b/_proposals/community/secretSanta.md
@@ -1,0 +1,27 @@
+---
+layout: proposal
+title: Secret Santa
+authors: Svenja Nierwetberg
+subgroup: community
+category: completed
+date: 2020-10-15
+---
+
+Run a Secret Santa contactless gift exchange for the entire SWC/GCNU
+
+
+### Purpose
+
+Support a festive spirit, acknowledge that this year’s celebrations will have to be different but stressing that Christmas isn’t cancelled
+
+
+### Implementation
+
+- decide on budget (proposed £10)
+- decide on platform (proposed drawnames.co.uk - people can post wishlists and anonymously get in touch with their gift recipient)
+- decide on gift exchange date (proposed 17th Dec)
+- advertise on Slack / email, ask to sign up until 4th Dec
+- draw names on 5th Dec
+- make sure people check the name they have drawn
+- organise gift drop-off boxes in the 5th floor library
+- start a slack thread for people to share their gifts and express their gratitude

--- a/_proposals/community/socialClubs.md
+++ b/_proposals/community/socialClubs.md
@@ -1,0 +1,26 @@
+---
+layout: proposal
+title: Social Clubs
+authors: Hernando Martinez Vergara
+subgroup: community
+category: active
+date: 2020-10-15
+---
+
+Establish a body that supports social interest groups
+
+
+### Purpose
+
+Increase interactions across SWC-Gatsby building, increase sense of belonging, increase wellbeing.
+
+
+### Implementation
+
+- explore opportunities to get SWC funding
+- transform existing endeavours (e.g. squash, pingpong, bookclub, choir) into Social Clubs
+- draft a guide of what fits within the limits of a Social Club and the steps one would have to take to create a new Social Club
+- create a virtual/physicial platform for advertising Social Clubs
+- constitute a committee to oversee the creation of new Social Clubs and allocate funding
+- advertise this idea to the building
+- suggestion: call the initiator of a Social Club the Principal Instigator (PI)

--- a/_proposals/community/swcArtDeco.md
+++ b/_proposals/community/swcArtDeco.md
@@ -1,0 +1,21 @@
+---
+layout: proposal
+title: Deco of SWC
+authors: Hernando Martinez Vergara
+subgroup: community
+category: active
+date: 2020-12-09
+---
+
+Improve the building interior
+
+
+### Purpose
+
+The beautiful SWC building is currently too monotone in its colors, with very little decoration that makes all areas look the same. Some ideas have been raised in order to change this, but they have never been collected into a common effort.
+
+
+### Implementation
+
+- buy more plants for office spaces and organise the care-taking so they don't die
+- coordinate with artists and scientists to create internal science art, and fill the walls with it. Anything could go, from microscopy images, to 3D printed stuff.

--- a/_proposals/community/teaHoursForEveryone.md
+++ b/_proposals/community/teaHoursForEveryone.md
@@ -1,0 +1,32 @@
+---
+layout: proposal
+title: Tea Hours for Everyone (THfE)
+authors: Svenja Nierwetberg, Zane Mitrevica, Hernando Martinez Vergara, Blanche Bettina Kollo
+subgroup: community
+category: active
+date: 2020-10-15
+---
+
+Make alternaTEA hours the norm
+
+### Concept
+
+Make the tea hours fun and accessible to everyone by replacing data-heavy neuroscience presentations with games and entertaining popular science talks. While tea hours cannot happen in person, focus particularly on activities that require active participation.
+
+
+### Purpose
+
+Increase the sense of belonging for everyone in the building, regardless of occupation or career stage
+
+
+### Implementation
+
+**early idea 2020-10-15**
+- create an organiser rota such that all parties from SWC/GCNU are represented
+- write organiser guidelines
+- define the Best Tea Hour Award
+- organise a few tea hours as an example
+
+**a more realistic idea 2021-01-08**
+- organise, on average, one alternaTEA hour per month
+- perhaps reconsider the early idea once in-person tea hours resume


### PR DESCRIPTION
Transformed our existing (active & completed) proposals into the required format. 

I skipped the `Stakeholders` heading because participation in most of our projects is entirely voluntary (perhaps except the Art Deco project?). Could also add the section and say exactly that, if it was preferable. 

Also, I wasn't always sure who to put as the author, since it was a team effort as far as I remember. The content/format/names (e.g. the THfE abbreviation) might not be ideal either. This is meant just to get us started with the new platform, so please comment.